### PR TITLE
null protection in QueryResult.R. Fixes SYNR-280

### DIFF
--- a/R/QueryResult.R
+++ b/R/QueryResult.R
@@ -54,6 +54,7 @@ QueryResult$methods(
       else {
         query <- paste(queryStatement, "limit", n, "offset", offset)
         result <- synapseQuery(query)
+        if (is.null(result)) result <- data.frame()
         offset <<- as.integer(offset + nrow(result))
         totalNumberOfResults <<- as.integer(attr(result, "totalNumberOfResults"))
       }

--- a/inst/integrationTests/test_QueryResult.R
+++ b/inst/integrationTests/test_QueryResult.R
@@ -3,6 +3,9 @@
 ## Author: J. Christopher Bare <chris.bare@sagebase.org>
 ###############################################################################
 
+## to run:
+## synapseClient:::.integrationTest(testFileRegexp="test_QueryResult.R")
+
 integrationTestQueryResult_Fetch <- function() {
   qr <- synapseClient:::QueryResult$new('select id, name, parentId from dataset', blockSize=25)
   df <- qr$fetch()
@@ -40,6 +43,18 @@ integrationTestQueryResult_CollectAll <- function() {
   qr$collect()
   df <- qr$collectAll()
   checkEquals(nrow(df), 40)
+}
+
+integrationTestQueryResult_EmptyResult <- function() {
+  # query that should have no results
+  qr <- synapseClient:::QueryResult$new(
+    'select id, name, parentId from entity where parentId=="-1" limit 100', blockSize=25)
+  checkEquals(length(qr), 0)
+  df <- qr$collect()
+  # should result in an empty data frame
+  checkEquals(class(df), "data.frame")
+  checkEquals(nrow(df), 0)
+  checkEquals(ncol(df), 0)
 }
 
 


### PR DESCRIPTION
Enforced that the collect method on query result returns an empty data frame if there are no results to the query. Fixes SYNR-280.
