### PR TITLE
Comment out DELETE /filehandle

### DIFF
--- a/inst/integrationTests/test_FileStoreGet.R
+++ b/inst/integrationTests/test_FileStoreGet.R
@@ -440,10 +440,10 @@ roundTripIntern<-function(project) {
   # delete the cached file
   deleteEntity(downloadedFile)
   # clean up downloaded file
-  handleUri<-sprintf("/fileHandle/%s", storedFile@fileHandle$id)
-  synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
-  handleUri<-sprintf("/fileHandle/%s", updatedFile2@fileHandle$id)
-  synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+  # handleUri<-sprintf("/fileHandle/%s", storedFile@fileHandle$id)
+  # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+  # handleUri<-sprintf("/fileHandle/%s", updatedFile2@fileHandle$id)
+  # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
 }
 
 
@@ -508,8 +508,8 @@ integrationTestAddToNewFILEEntity <-
   # delete the file
   deleteEntity(downloadedFile)
   # clean up downloaded file
-  handleUri<-sprintf("/fileHandle/%s", storedFile@fileHandle$id)
-  synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+  # handleUri<-sprintf("/fileHandle/%s", storedFile@fileHandle$id)
+  # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
 }
 
 # test that legacy *Entity based methods work on File objects, cont.
@@ -541,8 +541,8 @@ integrationTestReplaceFile<-function() {
     # delete the file
     deleteEntity(downloadedFile)
     # clean up downloaded file
-    handleUri<-sprintf("/fileHandle/%s", newStoredFile@fileHandle$id)
-    synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+    # handleUri<-sprintf("/fileHandle/%s", newStoredFile@fileHandle$id)
+    # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
   }
 
 
@@ -573,8 +573,8 @@ integrationTestLoadEntity<-function() {
   # delete the file
   deleteEntity(loadedEntity)
   # clean up downloaded file
-  handleUri<-sprintf("/fileHandle/%s", loadedEntity2@fileHandle$id)
-  synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+  # handleUri<-sprintf("/fileHandle/%s", loadedEntity2@fileHandle$id)
+  # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
 }
 
 integrationTestSerialization<-function() {

--- a/inst/integrationTests/test_entityFileAccess.R
+++ b/inst/integrationTests/test_entityFileAccess.R
@@ -54,9 +54,9 @@ integrationTestEntityFileAccess <-
     
     
     # delete the file handle
-    handleUri<-sprintf("/fileHandle/%s", fileHandle$id)
-    synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
-    
-    handleUri<-sprintf("/fileHandle/%s", fileHandle$id)
-    synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+    # handleUri<-sprintf("/fileHandle/%s", fileHandle$id)
+    # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+    # 
+    # handleUri<-sprintf("/fileHandle/%s", fileHandle$id)
+    # synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
 }

--- a/inst/integrationTests/test_wikiService.R
+++ b/inst/integrationTests/test_wikiService.R
@@ -110,8 +110,8 @@ integrationTestWikiCRUD <-
   checkException(synGetWiki(project, propertyValue(wikiPage2, "id")))
   
   # delete the file handles
-  for (fileHandleId in fileHandleIds) {
-    handleUri<-sprintf("/fileHandle/%s", fileHandleId)
-    synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
-  }
+  # for (fileHandleId in fileHandleIds) {
+  #   handleUri<-sprintf("/fileHandle/%s", fileHandleId)
+  #   synapseClient:::synapseDelete(handleUri, endpoint=synapseFileServiceEndpoint())
+  # }
 }


### PR DESCRIPTION
Commented out all instances of deleting file handles.  That operation fails due to remapping of delete into trash canning.
