### PR TITLE
MD5 is not an integer

### DIFF
--- a/R/checkInteger.R
+++ b/R/checkInteger.R
@@ -27,7 +27,7 @@ checkInteger <- function(x){
       if(any(mk)) {
         thisVal[mk] <- FALSE
       }
-      if (is.null(attr(try(as.character(xx)), "class"))) {
+      if (class(try(as.character(xx), silent=TRUE)) != "try-error") {
           # as.integer() and as.numeric() may interpret a string as '0'
           xx <- gsub("^-","",xx) # Remove leading '-'
           if (regexpr('\\D', xx) >= 0) {

--- a/inst/unitTests/test_checkInteger.R
+++ b/inst/unitTests/test_checkInteger.R
@@ -48,6 +48,18 @@ unitTestCheckSingleValue <-
   
   val <- "53082535172170281e54918781912015"
   checkTrue(!synapseClient:::checkInteger(val))
+  
+  val <- "-12345e12345"
+  checkTrue(!synapseClient:::checkInteger(val))
+  
+  val <- "--12345"
+  checkTrue(!synapseClient:::checkInteger(val))
+  
+  val <- "12345e+0"
+  checkTrue(!synapseClient:::checkInteger(val))
+  
+  val <- "12345e-0"
+  checkTrue(!synapseClient:::checkInteger(val))
 }
 
 unitTestFactors <-


### PR DESCRIPTION
Prevents CheckInteger(...) from classifying an MD5 as an integer.  
