### PR TITLE
checkInteger - False for strings

### DIFF
--- a/R/checkInteger.R
+++ b/R/checkInteger.R
@@ -13,7 +13,7 @@ checkInteger <- function(x){
     }else{
       xx <- x
     }
-    if(any(isS4(xx)) | length(xx) == 0L | is.list(xx)){
+    if(any(isS4(xx)) | length(xx) == 0L | is.list(xx) | is.character(xx)){
       result <- c(result, FALSE)
     }else{
       suppressWarnings(thisVal <- tryCatch({

--- a/inst/unitTests/test_checkInteger.R
+++ b/inst/unitTests/test_checkInteger.R
@@ -13,13 +13,13 @@ unitTestCheckSingleValue <-
   checkTrue(synapseClient:::checkInteger(val))
   
   val <- "5"
-  checkTrue(synapseClient:::checkInteger(val))
+  checkTrue(!synapseClient:::checkInteger(val))
   
   val <- 5.0000000
   checkTrue(synapseClient:::checkInteger(val))
   
   val <- "5L"
-  checkTrue(synapseClient:::checkInteger(val))
+  checkTrue(!synapseClient:::checkInteger(val))
   
   val <- 5 + .Machine$double.eps
   checkTrue(synapseClient:::checkInteger(val))


### PR DESCRIPTION
Avoid potential future problems by not parsing strings as numbers and attempting to see if that parsing is an integer or not.  
