### PR TITLE
Fix for submit("evaluation ID", ...)

### DIFF
--- a/R/submit.R
+++ b/R/submit.R
@@ -26,6 +26,7 @@ submit<-function(evaluation, entity, submissionName, teamName, silent=F) {
     if (is.null(evaluationId)) stop("The Evaluation provided does not have an ID.")
   } else if (is(evaluation, "character")) {
     evaluationId<-evaluation
+    evaluation <- synGetEvaluation(evaluationId)
   } else {
     stop("You must provide an evaluation or and evaluation ID.")
   }

--- a/inst/unitTests/test_submit.R
+++ b/inst/unitTests/test_submit.R
@@ -1,0 +1,43 @@
+# Unit test for submitting to evaluation
+###############################################################################
+
+.setUp <-
+  function() {
+    
+}
+
+.tearDown <- function() {
+    synapseClient:::.unmockAll()
+}
+
+unitTestSubmit_no_submissionReceiptMessage <- function() {
+    # Intercept all the calls to other methods
+    accessRequirementUnfulfilled_called <- FALSE
+    synGetEvaluation_called <- FALSE
+    SubmissionListConstructor_called <- FALSE
+    synCreateSubmission_called <- FALSE
+    synapseClient:::.mock("synapseGet", function(uri, ...) {
+        if (!grep("accessRequirementUnfulfilled", uri)) {
+            stop("Mocked an unexpected call")
+        }
+        accessRequirementUnfulfilled_called <<- TRUE
+        return(list(totalNumberOfResults=0))
+    })
+    synapseClient:::.mock("synGetEvaluation", function(id, ...) {
+        synGetEvaluation_called <<- TRUE
+        return(Evaluation(id=id))
+    })
+    synapseClient:::.mock("SubmissionListConstructor", function(...) {SubmissionListConstructor_called <<- TRUE})
+    synapseClient:::.mock("synCreateSubmission", function(...) {synCreateSubmission_called <<- TRUE})
+    
+    # As per SYNR-626, pass in an ID, not an Evaluation object
+    # The method should fetch the evaluation to show the proper confirmation message
+    evaluation <- "evalId"
+    entity <- File(id="fileId", parentId="parentId", etag="etag", name="name")
+    submit(evaluation, entity)
+    checkTrue(accessRequirementUnfulfilled_called)
+    checkTrue(synGetEvaluation_called)
+    checkTrue(SubmissionListConstructor_called)
+    checkTrue(synCreateSubmission_called)
+}
+


### PR DESCRIPTION
Submission to evaluation should convert eval ID to eval if necessary
