### PR TITLE
Fixed issues with tools/build.sh

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,4 +2,4 @@
 tools/prebuild.sh
 # Now build the package
 R CMD BUILD .
-R CMD INSTALL synapseClient_1.4-4.tar.gz
+R CMD INSTALL synapseClient_1.4-6.tar.gz


### PR DESCRIPTION
On my linux box, using lowercase sub-commands to R is problematic. Also, the currently built version is 1.4-6.
