### PR TITLE
Add ability to set config file path for synLogin

### DIFF
--- a/R/synapseLogin.R
+++ b/R/synapseLogin.R
@@ -75,7 +75,7 @@ synapseLogin <- function(username = "", password = "", sessionToken = "", apiKey
         
         ## Need to read from the config file
         } else {
-            config <- try(ConfigParser())
+            config <- try(ConfigParser(credentials$configPath))
             if (class(config) != "try-error") {
                 if (all(Config.hasOption(config, "authentication", "username"))) {
                     userName(Config.getOption(config, "authentication", "username"))

--- a/R/synapseLogin.R
+++ b/R/synapseLogin.R
@@ -11,7 +11,7 @@ setApiCredentials <-
   hmacSecretKey(secretKey)
 }
 
-synapseLogin <- function(username = "", password = "", sessionToken = "", apiKey = "", rememberMe = FALSE) {
+synapseLogin <- function(username = "", password = "", sessionToken = "", apiKey = "", configPath = "~/.synapseConfig", rememberMe = FALSE) {
     ## parameters must be of length 1
     if(any(length(username) !=1 || length(password) != 1 || length(sessionToken) != 1 || length(apiKey) != 1))
         stop("Please provide a single username and password")

--- a/R/synapseLogin.R
+++ b/R/synapseLogin.R
@@ -26,7 +26,8 @@ synapseLogin <- function(username = "", password = "", sessionToken = "", apiKey
     if(is.null(apiKey))       apiKey <- ""
     
     credentials <- list(username = username, password = password, 
-                        sessionToken = sessionToken, apiKey = apiKey)
+                        sessionToken = sessionToken, apiKey = apiKey,
+                        configPath = configPath)
     synapseLogout(localOnly=TRUE, silent=TRUE)
     .doAuth(credentials)
   

--- a/man/synapseLogin.Rd
+++ b/man/synapseLogin.Rd
@@ -13,6 +13,7 @@ synapseLogin(username, password, rememberMe=F)
 synapseLogin(username = ..., apiKey = ..., rememberMe=F)
 synapseLogin(sessionToken = ..., rememberMe=F)
 synapseLogin(username = ..., rememberMe=F)
+synapseLogin(configPath)
 synapseLogin()
 synapseLogout(localOnly=FALSE)
 invalidateAPIKey()
@@ -22,6 +23,7 @@ invalidateAPIKey()
   \item{username}{Synapse username, usually an email}
   \item{password}{Password associated with the username}
   \item{apiKey}{Can be found online by logging in and going to the Settings tab of your profile page at www.synapse.org}
+    \item{configPath}{Path to configuration file containing username and password or API key. Defaults to ~/.synapseConfig.}
   \item{sessionToken}{Usage not recommended}
   \item{rememberMe}{Boolean indicated whether login should store session information on the local machine.  Defaults to FALSE}
   \item{localOnly}{Boolean controlling whether logout is done locally only, or propagated to Synapse}


### PR DESCRIPTION
Allow the user to specify where the config file is that holds their credentials to log into Synapse using `synLogin`.

Use cases: switching users quickly for testing purposes, operating on compute clusters where home directories are created ad hoc (and hence do not have the current user's .synapseConfig at creation).