### PR TITLE
import read.table from utils

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,7 +3,7 @@ import(RCurl, methods)
 importFrom(rjson, toJSON, fromJSON)
 importFrom(tools, md5sum)
 importFrom(digest, digest, hmac)
-importFrom(utils, edit, compareVersion, packageDescription, install.packages, installed.packages)
+importFrom(utils, edit, compareVersion, packageDescription, install.packages, installed.packages, read.table)
 
 ## package has a dynamic library
 useDynLib(synapseClient)


### PR DESCRIPTION
I think this might fix the following complaint from R CMD check for mPowerProcessing:

> It looks like this package (or one of its dependent packages) has an
> unstated dependence on a standard package.  All dependencies must be
> declared in DESCRIPTION.
> See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
> manual. checking whether the package can be unloaded cleanly ... WARNING
> Error : .onLoad failed in loadNamespace() for 'synapseClient', details:
>   call: readS4ClassesToGenerate()
>   error: could not find function "read.table"
> Error: package or namespace load failed for ‘mPowerProcessing’
> Execution halted checking whether the namespace can be loaded with stated dependencies ... WARNING
> Error: .onLoad failed in loadNamespace() for 'synapseClient', details:
>   call: readS4ClassesToGenerate()
>   error: could not find function "read.table"
> Execution halted
> 
